### PR TITLE
Add core logic for deck service

### DIFF
--- a/internal/deck/service.go
+++ b/internal/deck/service.go
@@ -1,0 +1,50 @@
+package deck
+
+import (
+	"math/rand"
+	"time"
+)
+
+type Card struct {
+	Suit string
+	Rank string
+}
+
+type Deck struct {
+	cards []Card
+}
+
+func NewDeck() *Deck {
+	suits := []string{"Hearts", "Diamonds", "Clubs", "Spades"}
+	ranks := []string{"2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K", "A"}
+
+	var cards []Card
+	for _, suit := range suits {
+		for _, rank := range ranks {
+			cards = append(cards, Card{Suit: suit, Rank: rank})
+		}
+	}
+
+	return &Deck{cards: cards}
+}
+
+func (d *Deck) Shuffle() {
+	rand.Seed(time.Now().UnixNano())
+	rand.Shuffle(len(d.cards), func(i, j int) {
+		d.cards[i], d.cards[j] = d.cards[j], d.cards[i]
+	})
+}
+
+func (d *Deck) Draw() Card {
+	if len(d.cards) == 0 {
+		return Card{}
+	}
+
+	card := d.cards[0]
+	d.cards = d.cards[1:]
+	return card
+}
+
+func (d *Deck) Reset() {
+	*d = *NewDeck()
+}

--- a/internal/deck/service_test.go
+++ b/internal/deck/service_test.go
@@ -1,0 +1,41 @@
+package deck
+
+import (
+	"testing"
+)
+
+func TestNewDeck(t *testing.T) {
+	deck := NewDeck()
+	if len(deck.cards) != 52 {
+		t.Errorf("Expected 52 cards, got %d", len(deck.cards))
+	}
+}
+
+func TestShuffle(t *testing.T) {
+	deck := NewDeck()
+	firstCard := deck.cards[0]
+	deck.Shuffle()
+	if deck.cards[0] == firstCard {
+		t.Errorf("Expected first card to be different after shuffle")
+	}
+}
+
+func TestDraw(t *testing.T) {
+	deck := NewDeck()
+	card := deck.Draw()
+	if len(deck.cards) != 51 {
+		t.Errorf("Expected 51 cards after draw, got %d", len(deck.cards))
+	}
+	if card == (Card{}) {
+		t.Errorf("Expected a valid card, got an empty card")
+	}
+}
+
+func TestReset(t *testing.T) {
+	deck := NewDeck()
+	deck.Draw()
+	deck.Reset()
+	if len(deck.cards) != 52 {
+		t.Errorf("Expected 52 cards after reset, got %d", len(deck.cards))
+	}
+}


### PR DESCRIPTION
Fixes #2

Implement core logic for the deck service and add unit tests.

* **Deck Service Implementation**
  - Define `Card` struct with `Suit` and `Rank` fields.
  - Define `Deck` struct with a slice of `Card`.
  - Implement `NewDeck` function to initialize a deck with 52 cards.
  - Implement `Shuffle` method to shuffle the deck.
  - Implement `Draw` method to draw a card from the deck.
  - Implement `Reset` method to reset the deck to its initial state.

* **Unit Tests**
  - Add `TestNewDeck` to verify the deck contains 52 cards.
  - Add `TestShuffle` to verify the deck is shuffled.
  - Add `TestDraw` to verify drawing a card reduces the deck size.
  - Add `TestReset` to verify the deck is reset to 52 cards.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/noontts/poker-go-tui/issues/2?shareId=4df44337-fd0e-4e26-ae89-e90c350a297f).